### PR TITLE
Fix connection pool counter handling

### DIFF
--- a/src/connection_pool/mcp_connection_pool.c
+++ b/src/connection_pool/mcp_connection_pool.c
@@ -153,8 +153,10 @@ socket_handle_t mcp_connection_pool_get(mcp_connection_pool_t* pool, int timeout
                     free(pooled_conn);
 
                     // Update counts but keep total the same
-                    pool->idle_count--;
+                    pool->active_count--;
                     pool->total_count--;
+
+                    pool->total_connections_closed++;
 
                     // Continue the loop to get another connection
                     continue;
@@ -182,8 +184,9 @@ socket_handle_t mcp_connection_pool_get(mcp_connection_pool_t* pool, int timeout
                     free(pooled_conn);
 
                     // Update counts and statistics
-                    pool->idle_count--;
+                    pool->active_count--;
                     pool->total_count--;
+                    pool->total_connections_closed++;
                     pool->failed_health_checks++;
 
                     // Continue the loop to get another connection


### PR DESCRIPTION
## Summary
- fix double-decrement of idle_count when closing invalid idle connections
- ensure active_count and total_connections_closed are updated when an idle connection is closed before reuse

## Testing
- `cc -c src/connection_pool/mcp_connection_pool.c -I include`
- `python3 -m pytest -q python/test_custom_headers.py` *(fails: ModuleNotFoundError / fixture not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fbf157070832a920e932a7cb20b7a