### PR TITLE
Fix schema cache leak

### DIFF
--- a/src/json/mcp_json_schema_cache.c
+++ b/src/json/mcp_json_schema_cache.c
@@ -388,6 +388,7 @@ mcp_compiled_schema_t* mcp_json_schema_cache_find(mcp_json_schema_cache_t* cache
             mcp_rwlock_write_unlock(cache->cache_lock);
 
             mcp_log_debug("Schema cache hit: %s", schema_id);
+            free(schema_id);
             return schema;
         }
     } else {


### PR DESCRIPTION
## Summary
- fix memory leak in `mcp_json_schema_cache_find`

## Testing
- `cmake ..`
- `make mcp_tests` *(fails: conflicting types for `mcp_transport_sthttp_client_create`)*

------
https://chatgpt.com/codex/tasks/task_e_684080e31958832a9ec5cb6612a35983