### PR TITLE
Fix typo in test comment

### DIFF
--- a/tests/test_mcp_tcp_transport.c
+++ b/tests/test_mcp_tcp_transport.c
@@ -25,7 +25,7 @@ void tearDown_tcp(void) {
 
 // --- Test Cases ---
 
-// Dummy callback for testing star
+// Dummy callback for testing start
 static char* dummy_message_callback(void* user_data, const void* data, size_t size, int* error_code) {
     (void)user_data;
     (void)data;


### PR DESCRIPTION
## Summary
- fix typo in test_mcp_tcp_transport comment

## Testing
- `cmake ..` *(fails: Could not find libwebsockets library)*

------
https://chatgpt.com/codex/tasks/task_e_68408724b5ac832a837a697cd51dae73